### PR TITLE
chore: :wrench: remove toc to avoid table overlap

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -27,6 +27,7 @@ website:
 
 format:
   onlimit-theme-html:
+    toc: false
     theme:
       - brand
     # TODO: Uncomment if using the goatcounter website visitor counter


### PR DESCRIPTION
# Description

This doesn't fix the issue of tables having different widths bc Quarto doesn't break/wrap the long variable names, but it does avoid the tables overlapping with the toc. And the toc doesn't really add anything too meaningful on these pages anyway, e.g., on the package overview page, all the headers in the toc can be seen when viewing the page:

<img width="1207" height="633" alt="image" src="https://github.com/user-attachments/assets/d489c17f-de2f-42de-85de-34af5c71cd70" />

Closes #82 

This PR needs a quick review.
