### PR TITLE
docs: :fire: remove "Overview" from navbar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,8 +10,6 @@ website:
     logo-alt: "ON LiMiT Feasibility Study Data"
     pinned: true
     left:
-      - text: "Overview"
-        href: index.qmd
       - text: "Data Package"
         href: docs/index.qmd
     tools:


### PR DESCRIPTION
# Description

Since it refers to `index.qmd`, this page is the landing page anyway and can be reached by clicking the website title.

Closes #81 

This PR needs a quick review.
