### PR TITLE
docs: 📝 add guide on writing code in `src/`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+## Layout of `src/`
+
+Similar to how `raw/` and `staging/` are organized, the Python files within
+`src/` are organized at the top level by `data` and `metadata`, then by source
+of the original data, and finally by the eventual resource name. The structure
+under `src/feasibility_data/` is:
+
+- `metadata/<source>/<resource>.py`: Python files within this directory contain
+  functions that are used to convert the raw dictionaries into the final
+  `datapackage.json` metadata file. Functions within these modules can be named
+  without needing to state the source or resource (as the module path already
+  contains that information). For example, `metadata/redcap/vas.py` would
+  contain the functions for processing the metadata for the VAS resource from
+  the REDCap source.
+- `data/<source>/<resource>.py`: Same with the metadata files, but these contain
+  functions for taking the original raw data and converting them into the
+  `staging/` folder. Unlike the metadata above, raw data goes into `staging/`
+  first before being processed into the final data resource as Sprout needs to
+  run checks against the metadata before converting it into the final data
+  resource.
+- `common/`: Contains functions that are used across multiple resources. The
+  names of the Python files within are not standardized, but they should be
+  descriptive of the overall functionality they provide within.
+- `build.py`: This file lists all the functions (as
+  [pytask](https://pytask-dev.readthedocs.io/en/stable/) tasks) that are needed
+  to take the raw data and raw dictionaries and turn it all into a final data
+  package.


### PR DESCRIPTION
# Description

It's already getting a bit too disorganized, so this guide explains how the files and folders are organised and used within `src/`.

Related to #98

This PR needs an in-depth review.
