### PR TITLE
ci: :construction_worker: remove scope from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: monthly
     commit-message:
       prefix: ci
-      include: scope
 
   - package-ecosystem: uv
     directory: /
@@ -14,4 +13,3 @@ updates:
       interval: monthly
     commit-message:
       prefix: build
-      include: scope


### PR DESCRIPTION
# Description

Removes scope from dependabot

This PR needs no review.
