### PR TITLE
chore: 🔧 set path to `.config/typos.toml` in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.languageServer": "Pylance",
   "mypy.runUsingActiveInterpreter": true,
+  "typos.config": ".config/typos.toml",
   "files.insertFinalNewline": true,
   "conventionalCommits.emojiFormat": "emoji",
   "conventionalCommits.promptScopes": false


### PR DESCRIPTION
# Description

Forgot to add this.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
