### PR TITLE
chore 🏗️: add common `get_current_datetime()` function

### DIFF
--- a/src/feasibility_data/common/datetime.py
+++ b/src/feasibility_data/common/datetime.py
@@ -1,0 +1,6 @@
+from datetime import UTC, datetime
+
+
+def get_current_datetime() -> str:
+    """Get current datetime as a string."""
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H-%M-%SZ")

--- a/src/feasibility_data/data/redcap/raw.py
+++ b/src/feasibility_data/data/redcap/raw.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 from io import StringIO
 from pathlib import Path
 
 import polars as pl
 
 import feasibility_data.common.redcap as cr
+from feasibility_data.common.datetime import get_current_datetime
 
 
 def download_data(center: cr.Center) -> str:
@@ -30,7 +30,6 @@ def download_data(center: cr.Center) -> str:
 def write_data(raw_data_dir: Path, data: str) -> None:
     """Write the data as a timestamped file."""
     df = pl.read_csv(StringIO(data), separator=";", infer_schema=False)
-    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
-    data_path = raw_data_dir / f"{timestamp}.csv.gz"
+    data_path = raw_data_dir / f"{get_current_datetime()}.csv.gz"
     raw_data_dir.parent.mkdir(parents=True, exist_ok=True)
     df.write_csv(data_path, compression="gzip")


### PR DESCRIPTION
# Description

So we can reuse across data sources when writing to `raw/`.

As suggested in a comment in #173. 

